### PR TITLE
Manager TestCase Retrieve - Get Test Case Name

### DIFF
--- a/src/Utility/sfProvarCommandResult.ts
+++ b/src/Utility/sfProvarCommandResult.ts
@@ -14,11 +14,11 @@ import { GenericErrorHandler } from './genericErrorHandler.js';
  *
  */
 
+/* eslint-disable */
 export type SfProvarCommandResult = {
   success: boolean;
   value?: string;
-  testCasePaths?: string[];
-  testClassIds?: string[];
+  testCases?: any[];
   errors?: Error[] | object[];
 };
 
@@ -29,8 +29,7 @@ export function populateResult(
   messages: Messages<string>,
   log: Function,
   value?: string,
-  testCasePaths?: string[],
-  testCaseExternalIds?: string[]
+  testCases?: any[]
 ): SfProvarCommandResult {
   let result: SfProvarCommandResult = { success: true };
 
@@ -50,18 +49,12 @@ export function populateResult(
       success: true,
       value: value,
     };
-    testCasePaths != null
+    testCases != null && testCases.length > 0
       ? (result = {
           success: true,
-          testCasePaths: testCasePaths.map((testCasePath) => testCasePath.trim()),
+          testCases: testCases,
         })
-      : '';
-    testCaseExternalIds != null
-      ? (result = {
-          success: true,
-          testClassIds: testCaseExternalIds.map((testCaseExternalId) => testCaseExternalId.trim()),
-        })
-      : '';
+      : [];
   }
 
   return result;


### PR DESCRIPTION
for provar manager testcase retrieve command
now along with filePaths/externalIds we also want testcase name in json output.
so, the format of json output has changed from 
this
```
{
  "success": true,
  "testCasePaths": [
    "/tests/Timesheet/Validate Timesheet Hours.testcase",
  ]
}
{
  "success": true,
  "testClassIds": [
    "5003000000D8cuIQAA"
  ]
}

``` 
to 

```
 {
  "success": true,
  "testCases": [
    {
      "name": "Validate Timesheet Hours",
      "filePath": "/tests/Timesheet/Validate Timesheet Hours.testcase"
    }
  ]
}
{
  "success": true,
  "testCases": [
    {
      "name": "MyUnitTest1",
      "classId": "5003000000D8cuIQAA"
    }
  ]
}
```
So, changed the format of the result json.
used `any` as type here as the types are  created in manager plugin and if we want to use them here in utils need to import them and it'll create a cyclic dependency.
