### PR TITLE
PDX-33:  Error in execution of properties file when special characters are used in it.

### DIFF
--- a/src/Utility/userSupport.ts
+++ b/src/Utility/userSupport.ts
@@ -1,4 +1,5 @@
 import { sfCommandConstants } from '../constants/sfCommandConstants.js';
+import { specialCharReplacements } from '../constants/specialCharacterHandler.js';
 import { ErrorHandler } from './errorHandler.js';
 import { GenericErrorHandler } from './genericErrorHandler.js';
 import { GenericError } from './GenericError.js';
@@ -14,14 +15,12 @@ export class UserSupport {
   }
 
   public replaceSpecialCharacters(rawProperties: string): string {
-    return rawProperties
-      .replaceAll('^', '^^')
-      .replaceAll('&', '^&')
-      .replaceAll('<', '^<')
-      .replaceAll('>', '^>')
-      .replaceAll("'", "^'")
-      .replaceAll('|', '^|')
-      .replaceAll('\\', '^\\');
+    const result = [];
+    for (let i = 0; i < rawProperties.length; i++) {
+      const char = rawProperties[i];
+      result.push(specialCharReplacements[char] || char);
+    }
+    return result.join('');
   }
 
   /**

--- a/src/Utility/userSupport.ts
+++ b/src/Utility/userSupport.ts
@@ -15,13 +15,13 @@ export class UserSupport {
 
   public replaceSpecialCharacters(rawProperties: string): string {
     return rawProperties
-      .replace(/\^/g, '^^')
-      .replace(/&/g, '^&')
-      .replace(/</g, '^<')
-      .replace(/>/g, '^>')
-      .replace(/'/g, "^'")
-      .replace(/|/g, '^|')
-      .replace(/\\/g, '^\\')
+      .replaceAll('^', '^^')
+      .replaceAll('&', '^&')
+      .replaceAll('<', '^<')
+      .replaceAll('>', '^>')
+      .replaceAll("'", "^'")
+      .replaceAll('|', '^|')
+      .replaceAll('\\', '^\\')
       .replace(/"/g, '\\"');
   }
 

--- a/src/Utility/userSupport.ts
+++ b/src/Utility/userSupport.ts
@@ -10,7 +10,19 @@ export class UserSupport {
    */
   /* eslint-disable */
   public prepareRawProperties(rawProperties: string): string {
-    return '"' + rawProperties.replace(/"/g, '\\"') + '"';
+    return '"' + this.replaceSpecialCharacters(rawProperties) + '"';
+  }
+
+  public replaceSpecialCharacters(rawProperties: string): string {
+    return rawProperties
+      .replace(/\^/g, '^^')
+      .replace(/&/g, '^&')
+      .replace(/</g, '^<')
+      .replace(/>/g, '^>')
+      .replace(/'/g, "^'")
+      .replace(/|/g, '^|')
+      .replace(/\\/g, '^\\')
+      .replace(/"/g, '\\"');
   }
 
   /**

--- a/src/Utility/userSupport.ts
+++ b/src/Utility/userSupport.ts
@@ -21,6 +21,10 @@ export class UserSupport {
       .replaceAll('>', '^>')
       .replaceAll("'", "^'")
       .replaceAll('|', '^|')
+      .replaceAll('{', '^{')
+      .replaceAll('}', '^}')
+      .replaceAll('[', '^[')
+      .replaceAll(']', '^]')
       .replaceAll('\\', '^\\')
       .replace(/"/g, '\\"');
   }

--- a/src/Utility/userSupport.ts
+++ b/src/Utility/userSupport.ts
@@ -14,6 +14,11 @@ export class UserSupport {
     return '"' + this.replaceSpecialCharacters(rawProperties).replace(/"/g, '\\"') + '"';
   }
 
+  /**
+   * JSON library we are using in studio to deserialize this JSON to POJO is Gson and
+   * it automatically handles standard characters and escape sequences except for few,
+   * all other characters that are not explicitly handled will still be processed normally using the library’s default behavior.
+   */
   public replaceSpecialCharacters(rawProperties: string): string {
     const result = [];
     for (let i = 0; i < rawProperties.length; i++) {

--- a/src/Utility/userSupport.ts
+++ b/src/Utility/userSupport.ts
@@ -21,10 +21,6 @@ export class UserSupport {
       .replaceAll('>', '^>')
       .replaceAll("'", "^'")
       .replaceAll('|', '^|')
-      .replaceAll('{', '^{')
-      .replaceAll('}', '^}')
-      .replaceAll('[', '^[')
-      .replaceAll(']', '^]')
       .replaceAll('\\', '^\\')
       .replace(/"/g, '\\"');
   }

--- a/src/Utility/userSupport.ts
+++ b/src/Utility/userSupport.ts
@@ -10,7 +10,7 @@ export class UserSupport {
    */
   /* eslint-disable */
   public prepareRawProperties(rawProperties: string): string {
-    return '"' + this.replaceSpecialCharacters(rawProperties) + '"';
+    return '"' + this.replaceSpecialCharacters(rawProperties).replace(/"/g, '\\"') + '"';
   }
 
   public replaceSpecialCharacters(rawProperties: string): string {
@@ -21,8 +21,7 @@ export class UserSupport {
       .replaceAll('>', '^>')
       .replaceAll("'", "^'")
       .replaceAll('|', '^|')
-      .replaceAll('\\', '^\\')
-      .replace(/"/g, '\\"');
+      .replaceAll('\\', '^\\');
   }
 
   /**

--- a/src/constants/specialCharacterHandler.ts
+++ b/src/constants/specialCharacterHandler.ts
@@ -1,0 +1,9 @@
+export const specialCharReplacements: { [key: string]: string } = {
+  '^': '^^',
+  '&': '^&',
+  '<': '^<',
+  '>': '^>',
+  "'": "^'",
+  '|': '^|',
+  '\\': '^\\',
+};


### PR DESCRIPTION
RCA: Special characters did not remain exact when we deserialized POJO from the JSON string sent from the dx plugin.
Fix: used ^ sign as a prefix to special characters which keeps the value of special characters intact.
This issue is not specific to passwords but to whole json file