### PR TITLE
PDX-421: moved these constants to provardx-cli

### DIFF
--- a/src/constants/commandConstants.ts
+++ b/src/constants/commandConstants.ts
@@ -1,9 +1,4 @@
 export enum commandConstants {
-  SF_PROVAR_AUTOMATION_CONFIG_GENERATE_COMMAND = 'provar automation config generate',
-  SF_PROVAR_AUTOMATION_CONFIG_LOAD_COMMAND = 'provar automation config load',
-  SF_PROVAR_AUTOMATION_CONFIG_VALIDATE_COMMAND = 'provar automation config validate',
-  SF_PROVAR_AUTOMATION_CONFIG_SET_COMMAND = 'provar automation config set',
-  SF_PROVAR_AUTOMATION_CONFIG_GET_COMMAND = 'provar automation config get',
   SF_PROVAR_AUTOMATION_METADATA_DOWNLOAD_COMMAND = 'provar automation metadata download',
   SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND = 'provar automation test run',
   SF_PROVAR_AUTOMATION_PROJECT_COMPILE_COMMAND = 'provar automation project compile',


### PR DESCRIPTION
RCA: moved these constants to provardx-cli which were only needed there and nowhere else in different plugins
Fix: moved these constants to provardx-cli